### PR TITLE
Introduce the possibility to specify the number of cluster

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ var Semver = require('semver')
 // Declare internals
 var internals = {
   name: 'seneca-cluster',
+  nodes: require('os').cpus().length,
   error: Eraro({
     package: 'seneca',
     msgmap: {
@@ -18,10 +19,9 @@ var internals = {
 
 module.exports = function (options) {
   var seneca = this
-  var nodes = options.nodes || require('os').cpus().length
 
   seneca.decorate('cluster', internals.cluster)
-  seneca.decorate('nodes', nodes)
+  internals.nodes = options.nodes || internals.nodes
   return { name: internals.name }
 }
 
@@ -37,7 +37,7 @@ internals.cluster = function api_cluster () {
   var cluster = require('cluster')
 
   if (cluster.isMaster) {
-    for (var node = 0; node < seneca.nodes; node++) {
+    for (var node = 0; node < internals.nodes; node++) {
       cluster.fork()
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,9 +18,10 @@ var internals = {
 
 module.exports = function (options) {
   var seneca = this
+  var nodes = options.nodes || require('os').cpus().length
 
   seneca.decorate('cluster', internals.cluster)
-
+  seneca.decorate('nodes', nodes)
   return { name: internals.name }
 }
 
@@ -36,9 +37,9 @@ internals.cluster = function api_cluster () {
   var cluster = require('cluster')
 
   if (cluster.isMaster) {
-    require('os').cpus().forEach(function () {
+    for (var node = 0; node < seneca.nodes; node++) {
       cluster.fork()
-    })
+    }
 
     cluster.on('disconnect', function (worker) {
       cluster.fork()


### PR DESCRIPTION
This patch introduce the possibility to specify the number of nodes created by seneca-cluster, falling back to the cpu's core number if a value is not given.
This can be usefull to allocate a certain number of cores to seneca-cluster leaving some cores free for other usage (like database, other service and so on), which is a thing that is possible using the underlining cluster module.